### PR TITLE
enable role assignments to AKS infra resource group

### DIFF
--- a/archetypes/aks/archetypes.test.json
+++ b/archetypes/aks/archetypes.test.json
@@ -1,6 +1,6 @@
 {
     "general": {
-        "organization-name": "org",
+        "organization-name": "aksvdc",
         "tenant-id": "00000000-0000-0000-0000-000000000000",
         "deployment-user-id": "00000000-0000-0000-0000-000000000000",
         "vdc-storage-account-name": "knvdcstorage",
@@ -85,48 +85,67 @@
                 "rbac-client-appid": "00000000-0000-0000-0000-000000000000",
                 "rbac-tenant":"00000000-0000-0000-0000-000000000000",
 
-                "rbac": [
+                "aks-cluster-admin-rbac-role-id": "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
+                "aks-cluster-user-rbac-role-id": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
+                "reader-rbac-role-id": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+
+                "cluster-admin-group-id": "00000000-0000-0000-0000-000000000000",
+                "noc-user-group-id": "00000000-0000-0000-0000-000000000000",
+                "dev-user-group-id": "00000000-0000-0000-0000-000000000000",
+
+                "aks-rbac": [
                     {
                         "comments": "Azure Service Cluster Admin Role - Use Admin Persona Principal Id",
-                        "roleDefinitionId": "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.aks-cluster-admin-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.cluster-admin-group-id}"
                     },
                     {
                         "comments": "Azure Service Cluster User Role - Admin",
-                        "roleDefinitionId": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.aks-cluster-user-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.cluster-admin-group-id}"
                     },
                     {
                         "comments": "Azure Service Cluster User Role - NOC user",
-                        "roleDefinitionId": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.aks-cluster-user-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.noc-user-group-id}"
                     },
                     {
                         "comments": "Azure Service Cluster User Role - Devs",
-                        "roleDefinitionId": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.aks-cluster-user-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.dev-user-group-id}"
                     },
+
                     {
                         "comments": "Reader Role - Use Admin Persona Principal Id",
-                        "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.reader-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.cluster-admin-group-id}"
                     },
                     {
                         "comments": "Reader Role - Use Dev Persona Principal Id",
-                        "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.reader-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.dev-user-group-id}"
                     },
                     {
                         "comments": "Reader Role - Use NOC Persona Principal Id",
-                        "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-                        "principalId": "00000000-0000-0000-0000-000000000000",
-                        "scope": "/subscriptions/${general.workload.subscription-id}/resourceGroups/${general.organization-name}-${general.workload.deployment-name}-rg"
+                        "roleDefinitionId": "${general.workload.kubernetes.reader-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.noc-user-group-id}"
+                    }
+                ],
+                "aks-infra-rbac": [
+                    {
+                        "comments": "Reader Role - Use Admin Persona Principal Id",
+                        "roleDefinitionId": "${general.workload.kubernetes.reader-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.cluster-admin-group-id}"
+                    },
+                    {
+                        "comments": "Reader Role - Use Dev Persona Principal Id",
+                        "roleDefinitionId": "${general.workload.kubernetes.reader-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.dev-user-group-id}"
+                    },
+                    {
+                        "comments": "Reader Role - Use NOC Persona Principal Id",
+                        "roleDefinitionId": "${general.workload.kubernetes.reader-rbac-role-id}",
+                        "principalId": "${general.workload.kubernetes.noc-user-group-id}"
                     }
                 ],
                 "tiller-namespace": "tiller"
@@ -155,8 +174,8 @@
             "workload-net",
             "kv",
             "acr",
-            "ra",
             "aks",
+            "role-assignments",
             "permissions-scripts-pre-reqs",
             "scripts-pre-reqs",
             "create-ca-cert",
@@ -223,12 +242,12 @@
                     "dependencies": []
                 },
                 {
-                    "module": "ra",
+                    "module": "role-assignments",
                     "resource-group-name": "${general.organization-name}-${workload.deployment-name}-rg",
                     "source": {
                         "version": "1.0"
                     },
-                    "dependencies": []
+                    "dependencies": ["aks"]
                 },
                 {
                     "module": "aks",
@@ -498,7 +517,8 @@
             "enable-http-application-routing": "${general.workload.kubernetes.enable-http-application-routing}",
             "enable-oms-agent": "${general.workload.kubernetes.enable-oms-agent}",
             
-            "rbac": "${general.workload.kubernetes.rbac}",
+            "aks-rbac": "${general.workload.kubernetes.aks-rbac}",
+            "aks-infra-rbac": "${general.workload.kubernetes.aks-infra-rbac}",
             
             "ca-cert-key-name": "${general.organization-name}-${general.workload.deployment-name}-ca",
             "ca-name": "${general.organization-name}-${general.workload.deployment-name}-ca",

--- a/modules/aks/1.0/azureDeploy.json
+++ b/modules/aks/1.0/azureDeploy.json
@@ -365,9 +365,13 @@
         }
     ],
     "outputs": {
-        "scope": {
+        "rgId": {
             "type": "string",
             "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', reference(concat('Microsoft.ContainerService/managedClusters/', parameters('resource-name'))).nodeResourceGroup)]"
+        },
+        "rgName": {
+            "type": "string",
+            "value": "[reference(concat('Microsoft.ContainerService/managedClusters/', parameters('resource-name'))).nodeResourceGroup]"
         },
         "controlPlaneFQDN": {
             "type": "string",

--- a/modules/role-assignments/1.0/azureDeploy.json
+++ b/modules/role-assignments/1.0/azureDeploy.json
@@ -2,39 +2,81 @@
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "ra-role-assignments": {
+        "aks-role-assignments": {
             "type": "array",
             "metadata": {
-                "description": "Array of Role Assignment Information"
+                "description": "Array of Role Assignments for AKS resource group"
             }
         },
-        "scope": {
-            "type": "string",
-            "defaultValue": "none",
+        "aks-infra-role-assignments": {
+            "type": "array",
             "metadata": {
-                "description": "Array of Role Assignment Information"
+                "description": "Array of Role Assignment Information for AKS infra resource group"
+            }
+        },
+        "rgId": {
+            "type": "string",
+            "metadata": {
+                "description": "AKS Infra Resource group id from output of aks module"
+            }
+        },
+        "rgName": {
+            "type": "string",
+            "metadata": {
+                "description": "AKS Infra Resource group name captured from output of aks module"
             }
         }
     },
-    "variables": {
-    },
+    "variables": {},
     "resources": [
         {
+            "comments": "Role grants to the AKS resource group",
             "type": "Microsoft.Authorization/roleAssignments",
             "apiVersion": "2017-05-01",
             "copy": {
                 "name": "roleAssignmentLoop",
-                "count": "[length(parameters('ra-role-assignments'))]"
+                "count": "[length(parameters('aks-role-assignments'))]"
             },
-            "name": "[guid(subscription().id, resourceGroup().id, parameters('ra-role-assignments')[copyIndex()].roleDefinitionId, parameters('ra-role-assignments')[copyIndex()].principalId)]",
+            "name": "[guid(subscription().id, resourceGroup().id, parameters('aks-role-assignments')[copyIndex()].roleDefinitionId, parameters('aks-role-assignments')[copyIndex()].principalId)]",
             "properties": {
-              "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', parameters('ra-role-assignments')[copyIndex()].roleDefinitionId)]",
-              "principalId": "[parameters('ra-role-assignments')[copyIndex()].principalId]",
-              "scope": "[if(equals(parameters('scope'), 'none'), parameters('ra-role-assignments')[copyIndex()].scope, parameters('scope'))]"
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', parameters('aks-role-assignments')[copyIndex()].roleDefinitionId)]",
+                "principalId": "[parameters('aks-role-assignments')[copyIndex()].principalId]",
+                "scope": "[ResourceGroup().id]"
+            }
+        },
+        {
+            "comments": "Role grants to the AKS infrastructure resource group. We don't know the name until after the AKS deployment so we need a nested deployment to specify the target resource group",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "[concat('assignRoleToAksInfra','-',copyIndex())]",
+            "resourceGroup": "[parameters('rgName')]",
+            "copy": {
+                "name": "infraRoleAssignmentLoop",
+                "count": "[length(parameters('aks-infra-role-assignments'))]"
+            },                
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "name": "[guid(subscription().id, parameters('rgName'), parameters('aks-infra-role-assignments')[copyIndex('infraRoleAssignmentLoop')].roleDefinitionId, parameters('aks-infra-role-assignments')[copyIndex('infraRoleAssignmentLoop')].principalId)]",
+                            "apiVersion": "2017-09-01",
+                            "properties": {
+                                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', parameters('aks-infra-role-assignments')[copyIndex('infraRoleAssignmentLoop')].roleDefinitionId)]",
+                                "principalId": "[parameters('aks-infra-role-assignments')[copyIndex('infraRoleAssignmentLoop')].principalId]",
+                                "scope": "[parameters('rgId')]"
+                            }
+                        }
+                    ],
+                    "outputs": {}
+                }
             }
         }
     ],
-    "outputs": {
-        
-    }
+    "outputs": {}
 }

--- a/modules/role-assignments/1.0/azureDeploy.parameters.json
+++ b/modules/role-assignments/1.0/azureDeploy.parameters.json
@@ -1,0 +1,9 @@
+{
+    "aks-role-assignments": {
+        "value": "${workload.kubernetes.aks-rbac}"
+    },
+    "aks-infra-role-assignments": {
+        "value": "${workload.kubernetes.aks-infra-rbac}"
+    }
+
+}


### PR DESCRIPTION
Fix for #14 

- Adds separate role assignment arrays in archetype file for AKS and AKS Infra resource groups
- Make role-assignment module dependent on AKS module
- Add AKS infra resource group id and names as output of AKS template
- Update role-assignment module to apply role assignments separately for AKS and AKS infra resource groups. 

**Remaining TODO:**

- Update array handling in the role-assignment module to account for potential case of empty array
- Do more research to see if there is any way to use copy in the nested template rather than looping over deployments