### PR TITLE
fix tag values to provide an empty object

### DIFF
--- a/Modules/APIManagement/deploy.json
+++ b/Modules/APIManagement/deploy.json
@@ -81,7 +81,7 @@
     },
     "tagValues": {
       "type": "object",
-      "defaultValue": "",
+      "defaultValue": {},
       "metadata": {
         "description": "Optional. Azure Resource Tags object"
       }


### PR DESCRIPTION
Double quotes breaks the template from deploying. Requires an empty object to be passed for tags.