### PR TITLE
Removed reference to vnext in LABVMInstallHyperVURL

### DIFF
--- a/LabVM/azure-deploy.json
+++ b/LabVM/azure-deploy.json
@@ -25,7 +25,7 @@
     "LABVM-PUBIPName": "[concat(variables('LABVMName'), '-PIP')]",
     "LABVMInstallHyperVScriptFolder": ".",
     "LABVMInstallHyperVScriptFileName": "InstallLabVM.ps1",
-    "LABVMInstallHyperVURL": "https://raw.githubusercontent.com/Azure/vdc/vnext/LabVM/InstallLabVM.ps1"
+    "LABVMInstallHyperVURL": "https://raw.githubusercontent.com/Azure/vdc/master/LabVM/InstallLabVM.ps1"
   },
   "resources": [
     {


### PR DESCRIPTION
LABVMInstallHyperVURL had a reference to vnext causing the deployment to fail.